### PR TITLE
for some hexo renders of markdown, the css of image is not compatible with tag plugins mode, it should be set the image link style to markdown mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Support original markdown image expressions when **enabling `post_asset_folder`*
 
 URLs started with `http`, `https`, `//`, `/` or plain string(`path/asset.jpg`) will keep
 
+## Config
+
+If you want to render the image link as markdown style instead of tag plugins style, you should add following code to `_config.yml` of hexo project.
+
+```yaml
+asset:
+  tag_plugins_mode: false
+```
+
+- `tag_plugins_mode` : set the image link to [tag plugins](https://hexo.io/docs/asset-folders.html#Tag-Plugins-For-Relative-Path-Referencing) mode(`default mode, true`) or markdown mode(`false`).
+  - **tag plugins mode**: `{% asset_img slug [title] %}`
+  - **markdown mode**: `![image title](image url)`
 
 ## TODO
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,9 @@ module.exports = function (data) {
     (match, text, url, offset, string) => {
       if (/^\.\/(.*)/.test(url)) {
         const asset = url.replace(/\.\/(?:[^/]*\/)?(.*)/, '$1');
+        if (this.config.asset && (this.config.asset.tag_plugins_mode == false)) {
+          return `![${text}](${asset})`;
+        }
         return `{% asset_img ${text}${asset ? ` ${asset}` : ''} %}`;
       }
       // if (/^(https?:)?\/\//.test(url)) return string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-asset",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Support original markdown image expressions when enable `post_asset_folder`, and no need to use private hexo tags anymore",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
for some hexo renders of markdown, the css of image is not compatible with tag plugins mode, it should be set the image link style to markdown mode.