### PR TITLE
fix bug about `lib/index.js`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ module.exports = function (data) {
       // if (/^(https?:)?\/\//.test(url)) return string;
       // TODO replace other server's host
       // if (^/\//.test(url)) return customPath
-      return string;
+      return match;
     },
   );
   return data;


### PR DESCRIPTION
Content in Hexo blog has been rendered repeatly.
## Expected
![4R{)1ZK1 9J22BI2KADH)R4](https://user-images.githubusercontent.com/25796929/175905917-458fa982-8dbb-4309-b924-67a1873a0736.png)
## Actual
![d1867d957d264f81d371c1ee072850e](https://user-images.githubusercontent.com/25796929/175905965-da3b3357-7883-49e4-b808-5ffbb73021c1.png)
## Cause 
In `(match, text, url, offset, string)` , `match` means currentMatchStr while `string` means currentStr.
## Solution
Change `return string;` to `return match;`